### PR TITLE
Add ctime include

### DIFF
--- a/WikiSort.cpp
+++ b/WikiSort.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cassert>
 #include <cstring>
+#include <ctime>
 
 double Seconds() { return clock() * 1.0/CLOCKS_PER_SEC; }
 


### PR DESCRIPTION
Without the ctime, compiling with mingw and gcc 4.8.1 I get the error:

> g++ wikisort.cpp -o wikisort -O3
> wikisort.cpp: In function 'double Seconds()':
> wikisort.cpp:16:33: error: 'clock' was not declared in this scope
>  double Seconds() { return clock() \* 1.0/CLOCKS_PER_SEC; }
>                                  ^
> wikisort.cpp:16:41: error: 'CLOCKS_PER_SEC' was not declared in this scope
>  double Seconds() { return clock() \* 1.0/CLOCKS_PER_SEC; }
>                                          ^
> wikisort.cpp: In function 'int main()':
> wikisort.cpp:639:17: error: 'time' was not declared in this scope
>   srand(time(NULL));
>                  ^

It now works on Windows (with mingw) and Linux.
