### PR TITLE
Consistently use std::iter_swap to performs the swaps.

### DIFF
--- a/WikiSort.cpp
+++ b/WikiSort.cpp
@@ -1,7 +1,7 @@
 /***********************************************************
  WikiSort: a public domain implementation of "Block Sort"
  https://github.com/BonzaiThePenguin/WikiSort
- 
+
  to run:
  clang++ -o WikiSort.x WikiSort.cpp -O3
  (or replace 'clang++' with 'g++')
@@ -47,7 +47,7 @@ class Range {
 public:
 	size_t start;
 	size_t end;
-	
+
 	Range() {}
 	Range(size_t start, size_t end) : start(start), end(end) {}
 	size_t length() const { return end - start; }
@@ -88,11 +88,11 @@ template <typename T, typename Comparison>
 size_t FindFirstForward(const T array[], const T & value, const Range & range, const Comparison compare, const size_t unique) {
 	if (range.length() == 0) return range.start;
 	size_t index, skip = std::max(range.length()/unique, (size_t)1);
-	
+
 	for (index = range.start + skip; compare(array[index - 1], value); index += skip)
 		if (index >= range.end - skip)
 			return BinaryFirst(array, value, Range(index, range.end), compare);
-	
+
 	return BinaryFirst(array, value, Range(index - skip, index), compare);
 }
 
@@ -100,11 +100,11 @@ template <typename T, typename Comparison>
 size_t FindLastForward(const T array[], const T & value, const Range & range, const Comparison compare, const size_t unique) {
 	if (range.length() == 0) return range.start;
 	size_t index, skip = std::max(range.length()/unique, (size_t)1);
-	
+
 	for (index = range.start + skip; !compare(value, array[index - 1]); index += skip)
 		if (index >= range.end - skip)
 			return BinaryLast(array, value, Range(index, range.end), compare);
-	
+
 	return BinaryLast(array, value, Range(index - skip, index), compare);
 }
 
@@ -112,11 +112,11 @@ template <typename T, typename Comparison>
 size_t FindFirstBackward(const T array[], const T & value, const Range & range, const Comparison compare, const size_t unique) {
 	if (range.length() == 0) return range.start;
 	size_t index, skip = std::max(range.length()/unique, (size_t)1);
-	
+
 	for (index = range.end - skip; index > range.start && !compare(array[index - 1], value); index -= skip)
 		if (index < range.start + skip)
 			return BinaryFirst(array, value, Range(range.start, index), compare);
-	
+
 	return BinaryFirst(array, value, Range(index, index + skip), compare);
 }
 
@@ -124,11 +124,11 @@ template <typename T, typename Comparison>
 size_t FindLastBackward(const T array[], const T & value, const Range & range, const Comparison compare, const size_t unique) {
 	if (range.length() == 0) return range.start;
 	size_t index, skip = std::max(range.length()/unique, (size_t)1);
-	
+
 	for (index = range.end - skip; index > range.start && compare(value, array[index - 1]); index -= skip)
 		if (index < range.start + skip)
 			return BinaryLast(array, value, Range(range.start, index), compare);
-	
+
 	return BinaryLast(array, value, Range(index, index + skip), compare);
 }
 
@@ -169,7 +169,7 @@ namespace Wiki {
 		T *A_index = &from[A.start], *B_index = &from[B.start];
 		T *A_last = &from[A.end], *B_last = &from[B.end];
 		T *insert_index = &into[0];
-		
+
 		while (true) {
 			if (!compare(*B_index, *A_index)) {
 				*insert_index = *A_index;
@@ -192,7 +192,7 @@ namespace Wiki {
 			}
 		}
 	}
-	
+
 	// merge operation using an external buffer
 	template <typename T, typename Comparison>
 	void MergeExternal(T array[], const Range & A, const Range & B, const Comparison compare, T cache[]) {
@@ -200,7 +200,7 @@ namespace Wiki {
 		T *A_index = &cache[0], *B_index = &array[B.start];
 		T *A_last = &cache[A.length()], *B_last = &array[B.end];
 		T *insert_index = &array[A.start];
-		
+
 		if (B.length() > 0 && A.length() > 0) {
 			while (true) {
 				if (!compare(*B_index, *A_index)) {
@@ -216,11 +216,11 @@ namespace Wiki {
 				}
 			}
 		}
-		
+
 		// copy the remainder of A into the final array
 		std::copy(A_index, A_last, insert_index);
 	}
-	
+
 	// merge operation using an internal buffer
 	template <typename T, typename Comparison>
 	void MergeInternal(T array[], const Range & A, const Range & B, const Comparison compare, const Range & buffer) {
@@ -229,61 +229,61 @@ namespace Wiki {
 		T *A_index = &array[buffer.start], *B_index = &array[B.start];
 		T *A_last = &array[buffer.start + A.length()], *B_last = &array[B.end];
 		T *insert_index = &array[A.start];
-		
+
 		if (B.length() > 0 && A.length() > 0) {
 			while (true) {
 				if (!compare(*B_index, *A_index)) {
-					std::swap(*insert_index, *A_index);
+					std::iter_swap(insert_index, A_index);
 					A_index++;
 					insert_index++;
 					if (A_index == A_last) break;
 				} else {
-					std::swap(*insert_index, *B_index);
+					std::iter_swap(insert_index, B_index);
 					B_index++;
 					insert_index++;
 					if (B_index == B_last) break;
 				}
 			}
 		}
-		
+
 		// BlockSwap
 		std::swap_ranges(A_index, A_last, insert_index);
 	}
-	
+
 	// merge operation without a buffer
 	template <typename T, typename Comparison>
 	void MergeInPlace(T array[], Range A, Range B, const Comparison compare) {
 		if (A.length() == 0 || B.length() == 0) return;
-		
+
 		/*
 		 this just repeatedly binary searches into B and rotates A into position.
 		 the paper suggests using the 'rotation-based Hwang and Lin algorithm' here,
 		 but I decided to stick with this because it had better situational performance
-		 
+
 		 (Hwang and Lin is designed for merging subarrays of very different sizes,
 		 but WikiSort almost always uses subarrays that are roughly the same size)
-		 
+
 		 normally this is incredibly suboptimal, but this function is only called
 		 when none of the A or B blocks in any subarray contained 2√A unique values,
 		 which places a hard limit on the number of times this will ACTUALLY need
 		 to binary search and rotate.
-		 
+
 		 according to my analysis the worst case is √A rotations performed on √A items
 		 once the constant factors are removed, which ends up being O(n)
-		 
+
 		 again, this is NOT a general-purpose solution – it only works well in this case!
 		 kind of like how the O(n^2) insertion sort is used in some places
 		 */
-		
+
 		while (true) {
 			// find the first place in B where the first item in A needs to be inserted
 			size_t mid = BinaryFirst(array, array[A.start], B, compare);
-			
+
 			// rotate A into place
 			size_t amount = mid - A.end;
 			Rotate(array, A.length(), Range(A.start, mid));
 			if (B.end == mid) break;
-			
+
 			// calculate the new A and B ranges
 			B.start = mid;
 			A = Range(A.start + amount, B.start);
@@ -291,7 +291,7 @@ namespace Wiki {
 			if (A.length() == 0) break;
 		}
 	}
-	
+
 	// calculate how to scale the index value to the range within the array
 	// the bottom-up merge sort only operates on values that are powers of two,
 	// so scale down to that power of two, then use a fraction to scale back again
@@ -299,7 +299,7 @@ namespace Wiki {
 		size_t size, power_of_two;
 		size_t decimal, numerator, denominator;
 		size_t decimal_step, numerator_step;
-		
+
 	public:
 		Iterator(size_t size2, size_t min_level) {
 			size = size2;
@@ -309,28 +309,28 @@ namespace Wiki {
 			decimal_step = size/denominator;
 			begin();
 		}
-		
+
 		void begin() {
 			numerator = decimal = 0;
 		}
-		
+
 		Range nextRange() {
 			size_t start = decimal;
-			
+
 			decimal += decimal_step;
 			numerator += numerator_step;
 			if (numerator >= denominator) {
 				numerator -= denominator;
 				decimal++;
 			}
-			
+
 			return Range(start, decimal);
 		}
-		
+
 		bool finished() {
 			return (decimal >= size);
 		}
-		
+
 		bool nextLevel() {
 			decimal_step += decimal_step;
 			numerator_step += numerator_step;
@@ -338,15 +338,15 @@ namespace Wiki {
 				numerator_step -= denominator;
 				decimal_step++;
 			}
-			
+
 			return (decimal_step < size);
 		}
-		
+
 		size_t length() {
 			return decimal_step;
 		}
 	};
-	
+
 #if DYNAMIC_CACHE
 	// use a class so the memory for the cache is freed when the object goes out of scope,
 	// regardless of whether exceptions were thrown (only needed in the C++ version)
@@ -355,37 +355,37 @@ namespace Wiki {
 	public:
 		T *cache;
 		size_t cache_size;
-		
+
 		~Cache() {
 			if (cache) delete[] cache;
 		}
-		
+
 		Cache(size_t size) {
 			// good choices for the cache size are:
 			// (size + 1)/2 – turns into a full-speed standard merge sort since everything fits into the cache
 			cache_size = (size + 1)/2;
 			cache = new (std::nothrow) T[cache_size];
 			if (cache) return;
-			
+
 			// sqrt((size + 1)/2) + 1 – this will be the size of the A blocks at the largest level of merges,
 			// so a buffer of this size would allow it to skip using internal or in-place merges for anything
 			cache_size = sqrt(cache_size) + 1;
 			cache = new (std::nothrow) T[cache_size];
 			if (cache) return;
-			
+
 			// 512 – chosen from careful testing as a good balance between fixed-size memory use and run time
 			if (cache_size > 512) {
 				cache_size = 512;
 				cache = new (std::nothrow) T[cache_size];
 				if (cache) return;
 			}
-			
+
 			// 0 – if the system simply cannot allocate any extra memory whatsoever, no memory works just fine
 			cache_size = 0;
 		}
 	};
 #endif
-	
+
 	// bottom-up merge sort combined with an in-place merge algorithm for O(1) memory use
 	template <typename Iterator, typename Comparison>
 	void Sort(Iterator first, Iterator last, const Comparison compare) {
@@ -394,24 +394,30 @@ namespace Wiki {
 		typedef typename std::iterator_traits<Iterator>::value_type T;
 		const size_t size = last - first;
 		T *array = &first[0];
-		
+
 		// if the array is of size 0, 1, 2, or 3, just sort them like so:
 		if (size < 4) {
 			if (size == 3) {
 				// hard-coded insertion sort
-				if (compare(array[1], array[0])) std::swap(array[0], array[1]);
+				if (compare(array[1], array[0])) {
+                    std::iter_swap(array + 0, array + 1);
+				}
 				if (compare(array[2], array[1])) {
-					std::swap(array[1], array[2]);
-					if (compare(array[1], array[0])) std::swap(array[0], array[1]);
+					std::iter_swap(array + 1, array + 2);
+					if (compare(array[1], array[0])) {
+                        std::iter_swap(array + 0, array + 1);
+					}
 				}
 			} else if (size == 2) {
 				// swap the items if they're out of order
-				if (compare(array[1], array[0])) std::swap(array[0], array[1]);
+				if (compare(array[1], array[0])) {
+                    std::iter_swap(array + 0, array + 1);
+				}
 			}
-			
+
 			return;
 		}
-		
+
 		// sort groups of 4-8 items at a time using an unstable sorting network,
 		// but keep track of the original item orders to force it to be stable
 		// http://pages.ripco.net/~jgamble/nw.html
@@ -419,12 +425,13 @@ namespace Wiki {
 		while (!iterator.finished()) {
 			uint8_t order[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
 			Range range = iterator.nextRange();
-			
+
 			#define SWAP(x, y) \
 				if (compare(array[range.start + y], array[range.start + x]) || \
 					(order[x] > order[y] && !compare(array[range.start + x], array[range.start + y]))) { \
-					std::swap(array[range.start + x], array[range.start + y]); std::swap(order[x], order[y]); }
-			
+					std::iter_swap(array + range.start + x, array + range.start + y); \
+					std::iter_swap(order + x, order + y); }
+
 			if (range.length() == 8) {
 				SWAP(0, 1); SWAP(2, 3); SWAP(4, 5); SWAP(6, 7);
 				SWAP(0, 2); SWAP(1, 3); SWAP(4, 6); SWAP(5, 7);
@@ -433,7 +440,7 @@ namespace Wiki {
 				SWAP(1, 4); SWAP(3, 6);
 				SWAP(2, 4); SWAP(3, 5);
 				SWAP(3, 4);
-				
+
 			} else if (range.length() == 7) {
 				SWAP(1, 2); SWAP(3, 4); SWAP(5, 6);
 				SWAP(0, 2); SWAP(3, 5); SWAP(4, 6);
@@ -442,7 +449,7 @@ namespace Wiki {
 				SWAP(0, 3); SWAP(2, 5);
 				SWAP(1, 3); SWAP(2, 4);
 				SWAP(2, 3);
-				
+
 			} else if (range.length() == 6) {
 				SWAP(1, 2); SWAP(4, 5);
 				SWAP(0, 2); SWAP(3, 5);
@@ -450,7 +457,7 @@ namespace Wiki {
 				SWAP(0, 3); SWAP(1, 4);
 				SWAP(2, 4); SWAP(1, 3);
 				SWAP(2, 3);
-				
+
 			} else if (range.length() == 5) {
 				SWAP(0, 1); SWAP(3, 4);
 				SWAP(2, 4);
@@ -458,7 +465,7 @@ namespace Wiki {
 				SWAP(0, 3);
 				SWAP(0, 2); SWAP(1, 3);
 				SWAP(1, 2);
-				
+
 			} else if (range.length() == 4) {
 				SWAP(0, 1); SWAP(2, 3);
 				SWAP(0, 2); SWAP(1, 3);
@@ -466,7 +473,7 @@ namespace Wiki {
 			}
 		}
 		if (size < 8) return;
-		
+
 		// use a small cache to speed up some of the operations
 		#if DYNAMIC_CACHE
 			Cache<T> cache_obj (size);
@@ -480,13 +487,13 @@ namespace Wiki {
 			const size_t cache_size = 512;
 			T cache[cache_size];
 		#endif
-		
+
 		// then merge sort the higher levels, which can be 8-15, 16-31, 32-63, 64-127, etc.
 		while (true) {
 			// if every A and B block will fit into the cache, use a special branch specifically for merging with the cache
 			// (we use < rather than <= since the block size might be one more than iterator.length())
 			if (iterator.length() < cache_size) {
-				
+
 				// if four subarrays fit into the cache, it's faster to merge both pairs of subarrays into the cache,
 				// then merge the two merged subarrays from the cache back into the original array
 				if ((iterator.length() + 1) * 4 <= cache_size && iterator.length() * 4 <= size) {
@@ -497,7 +504,7 @@ namespace Wiki {
 						Range B1 = iterator.nextRange();
 						Range A2 = iterator.nextRange();
 						Range B2 = iterator.nextRange();
-						
+
 						if (compare(array[B1.end - 1], array[A1.start])) {
 							// the two ranges are in reverse order, so copy them in reverse order into the cache
 							std::copy(&array[A1.start], &array[A1.end], &cache[B1.length()]);
@@ -508,13 +515,13 @@ namespace Wiki {
 						} else {
 							// if A1, B1, A2, and B2 are all in order, skip doing anything else
 							if (!compare(array[B2.start], array[A2.end - 1]) && !compare(array[A2.start], array[B1.end - 1])) continue;
-							
+
 							// copy A1 and B1 into the cache in the same order
 							std::copy(&array[A1.start], &array[A1.end], &cache[0]);
 							std::copy(&array[B1.start], &array[B1.end], &cache[A1.length()]);
 						}
 						A1 = Range(A1.start, B1.end);
-						
+
 						// merge A2 and B2 into the cache
 						if (compare(array[B2.end - 1], array[A2.start])) {
 							// the two ranges are in reverse order, so copy them in reverse order into the cache
@@ -529,11 +536,11 @@ namespace Wiki {
 							std::copy(&array[B2.start], &array[B2.end], &cache[A1.length() + A2.length()]);
 						}
 						A2 = Range(A2.start, B2.end);
-						
+
 						// merge A1 and A2 from the cache into the array
 						Range A3 = Range(0, A1.length());
 						Range B3 = Range(A1.length(), A1.length() + A2.length());
-						
+
 						if (compare(cache[B3.end - 1], cache[A3.start])) {
 							// the two ranges are in reverse order, so copy them in reverse order into the array
 							std::copy(&cache[A3.start], &cache[A3.end], &array[A1.start + A2.length()]);
@@ -547,17 +554,17 @@ namespace Wiki {
 							std::copy(&cache[B3.start], &cache[B3.end], &array[A1.start + A1.length()]);
 						}
 					}
-					
+
 					// we merged two levels at the same time, so we're done with this level already
 					// (iterator.nextLevel() is called again at the bottom of this outer merge loop)
 					iterator.nextLevel();
-					
+
 				} else {
 					iterator.begin();
 					while (!iterator.finished()) {
 						Range A = iterator.nextRange();
 						Range B = iterator.nextRange();
-						
+
 						if (compare(array[B.end - 1], array[A.start])) {
 							// the two ranges are in reverse order, so a simple rotation should fix it
 							Rotate(array, A.length(), Range(A.start, B.end));
@@ -579,10 +586,10 @@ namespace Wiki {
 				//     6. merge each A block with any B values that follow, using the cache or the second internal buffer
 				// 7. sort the second internal buffer if it exists
 				// 8. redistribute the two internal buffers back into the array
-				
+
 				size_t block_size = sqrt(iterator.length());
 				size_t buffer_size = iterator.length()/block_size + 1;
-				
+
 				// as an optimization, we really only need to pull out the internal buffers once for each level of merges
 				// after that we can reuse the same buffers over and over, then redistribute it when we're finished with this level
 				Range buffer1 = Range(0, 0), buffer2 = Range(0, 0);
@@ -590,12 +597,12 @@ namespace Wiki {
 				struct { size_t from, to, count; Range range; } pull[2];
 				pull[0].from = pull[0].to = pull[0].count = 0; pull[0].range = Range(0, 0);
 				pull[1].from = pull[1].to = pull[1].count = 0; pull[1].range = Range(0, 0);
-				
+
 				// find two internal buffers of size 'buffer_size' each
 				// let's try finding both buffers at the same time from a single A or B subarray
 				size_t find = buffer_size + buffer_size;
 				bool find_separately = false;
-				
+
 				if (block_size <= cache_size) {
 					// if every A block fits into the cache then we won't need the second internal buffer,
 					// so we really only need to find 'buffer_size' unique values
@@ -605,19 +612,19 @@ namespace Wiki {
 					find = buffer_size;
 					find_separately = true;
 				}
-				
+
 				// we need to find either a single contiguous space containing 2√A unique values (which will be split up into two buffers of size √A each),
 				// or we need to find one buffer of < 2√A unique values, and a second buffer of √A unique values,
 				// OR if we couldn't find that many unique values, we need the largest possible buffer we can get
-				
+
 				// in the case where it couldn't find a single buffer of at least √A unique values,
 				// all of the Merge steps must be replaced by a different merge algorithm (MergeInPlace)
-				
+
 				iterator.begin();
 				while (!iterator.finished()) {
 					Range A = iterator.nextRange();
 					Range B = iterator.nextRange();
-					
+
 					// just store information about where the values will be pulled from and to,
 					// as well as how many values there are, to create the two internal buffers
 					#define PULL(_to) \
@@ -625,7 +632,7 @@ namespace Wiki {
 						pull[pull_index].count = count; \
 						pull[pull_index].from = index; \
 						pull[pull_index].to = _to
-					
+
 					// check A for the number of unique values we need to fill an internal buffer
 					// these values will be pulled out to the start of A
 					for (last = A.start, count = 1; count < find; last = index, count++) {
@@ -634,12 +641,12 @@ namespace Wiki {
 						assert(index < A.end);
 					}
 					index = last;
-					
+
 					if (count >= buffer_size) {
 						// keep track of the range within the array where we'll need to "pull out" these values to create the internal buffer
 						PULL(A.start);
 						pull_index = 1;
-						
+
 						if (count == buffer_size + buffer_size) {
 							// we were able to find a single contiguous section containing 2√A unique values,
 							// so this section can be used to contain both of the internal buffers we'll need
@@ -669,7 +676,7 @@ namespace Wiki {
 						buffer1 = Range(A.start, A.start + count);
 						PULL(A.start);
 					}
-					
+
 					// check B for the number of unique values we need to fill an internal buffer
 					// these values will be pulled out to the end of B
 					for (last = B.end - 1, count = 1; count < find; last = index - 1, count++) {
@@ -678,12 +685,12 @@ namespace Wiki {
 						assert(index > B.start);
 					}
 					index = last;
-					
+
 					if (count >= buffer_size) {
 						// keep track of the range within the array where we'll need to "pull out" these values to create the internal buffer
 						PULL(B.end);
 						pull_index = 1;
-						
+
 						if (count == buffer_size + buffer_size) {
 							// we were able to find a single contiguous section containing 2√A unique values,
 							// so this section can be used to contain both of the internal buffers we'll need
@@ -707,7 +714,7 @@ namespace Wiki {
 							// buffer2 will be pulled out from a 'B' subarray, so if the first buffer was pulled out from the corresponding 'A' subarray,
 							// we need to adjust the end point for that A subarray so it knows to stop redistributing its values before reaching buffer2
 							if (pull[0].range.start == A.start) pull[0].range.end -= pull[1].count;
-							
+
 							// we found a second buffer in a 'B' subarray containing √A unique values, so we're done!
 							buffer2 = Range(B.end - count, B.end);
 							break;
@@ -718,11 +725,11 @@ namespace Wiki {
 						PULL(B.end);
 					}
 				}
-				
+
 				// pull out the two ranges so we can use them as internal buffers
 				for (pull_index = 0; pull_index < 2; pull_index++) {
 					size_t length = pull[pull_index].count;
-					
+
 					if (pull[pull_index].to < pull[pull_index].from) {
 						// we're pulling the values out to the left, which means the start of an A subarray
 						index = pull[pull_index].from;
@@ -743,27 +750,27 @@ namespace Wiki {
 						}
 					}
 				}
-				
+
 				// adjust block_size and buffer_size based on the values we were able to pull out
 				buffer_size = buffer1.length();
 				block_size = iterator.length()/buffer_size + 1;
-				
+
 				// the first buffer NEEDS to be large enough to tag each of the evenly sized A blocks,
 				// so this was originally here to test the math for adjusting block_size above
 				//assert((iterator.length() + 1)/block_size <= buffer_size);
-				
+
 				// now that the two internal buffers have been created, it's time to merge each A+B combination at this level of the merge sort!
 				iterator.begin();
 				while (!iterator.finished()) {
 					Range A = iterator.nextRange();
 					Range B = iterator.nextRange();
-					
+
 					// remove any parts of A or B that are being used by the internal buffers
 					size_t start = A.start;
 					if (start == pull[0].range.start) {
 						if (pull[0].from > pull[0].to) {
 							A.start += pull[0].count;
-							
+
 							// if the internal buffer takes up the entire A or B subarray, then there's nothing to merge
 							// this only happens for very small subarrays, like √4 = 2, 2 * (2 internal buffers) = 4,
 							// which also only happens when cache_size is small or 0 since it'd otherwise use MergeExternal
@@ -782,21 +789,21 @@ namespace Wiki {
 							if (B.length() == 0) continue;
 						}
 					}
-					
+
 					if (compare(array[B.end - 1], array[A.start])) {
 						// the two ranges are in reverse order, so a simple rotation should fix it
 						Rotate(array, A.length(), Range(A.start, B.end));
 					} else if (compare(array[A.end], array[A.end - 1])) {
 						// these two ranges weren't already in order, so we'll need to merge them!
-						
+
 						// break the remainder of A into blocks. firstA is the uneven-sized first A block
 						Range blockA = Range(A.start, A.end);
 						Range firstA = Range(A.start, A.start + blockA.length() % block_size);
-						
+
 						// swap the first value of each A block with the values in buffer1
-						for (size_t indexA = buffer1.start, index = firstA.end; index < blockA.end; indexA++, index += block_size) 
-							std::swap(array[indexA], array[index]);
-						
+						for (size_t indexA = buffer1.start, index = firstA.end; index < blockA.end; indexA++, index += block_size)
+							std::iter_swap(array + indexA, array + index);
+
 						// start rolling the A blocks through the B blocks!
 						// when we leave an A block behind we'll need to merge the previous A block with any B blocks that follow it, so track that information as well
 						Range lastA = firstA;
@@ -804,14 +811,14 @@ namespace Wiki {
 						Range blockB = Range(B.start, B.start + std::min(block_size, B.length()));
 						blockA.start += firstA.length();
 						size_t indexA = buffer1.start;
-						
+
 						// if the first unevenly sized A block fits into the cache, copy it there for when we go to Merge it
 						// otherwise, if the second buffer is available, block swap the contents into that
 						if (lastA.length() <= cache_size)
 							std::copy(&array[lastA.start], &array[lastA.end], &cache[0]);
 						else if (buffer2.length() > 0)
 							BlockSwap(array, lastA.start, buffer2.start, lastA.length());
-						
+
 						if (blockA.length() > 0) {
 							while (true) {
 								// if there's a previous B block and the first value of the minimum A block is <= the last value of the previous B block,
@@ -820,18 +827,18 @@ namespace Wiki {
 									// figure out where to split the previous B block, and rotate it at the split
 									size_t B_split = BinaryFirst(array, array[indexA], lastB, compare);
 									size_t B_remaining = lastB.end - B_split;
-									
+
 									// swap the minimum A block to the beginning of the rolling A blocks
 									size_t minA = blockA.start;
 									for (size_t findA = minA + block_size; findA < blockA.end; findA += block_size)
 										if (compare(array[findA], array[minA]))
 											minA = findA;
 									BlockSwap(array, blockA.start, minA, block_size);
-									
+
 									// swap the first item of the previous A block back with its original value, which is stored in buffer1
-									std::swap(array[blockA.start], array[indexA]);
+									std::iter_swap(array + blockA.start, array + indexA);
 									indexA++;
-									
+
 									// locally merge the previous A block with the B values that follow it
 									// if lastA fits into the external cache we'll use that (with MergeExternal),
 									// or if the second internal buffer exists we'll use that (with MergeInternal),
@@ -842,14 +849,14 @@ namespace Wiki {
 										MergeInternal(array, lastA, Range(lastA.end, B_split), compare, buffer2);
 									else
 										MergeInPlace(array, lastA, Range(lastA.end, B_split), compare);
-									
+
 									if (buffer2.length() > 0 || block_size <= cache_size) {
 										// copy the previous A block into the cache or buffer2, since that's where we need it to be when we go to merge it anyway
 										if (block_size <= cache_size)
 											std::copy(&array[blockA.start], &array[blockA.start + block_size], cache);
 										else
 											BlockSwap(array, blockA.start, buffer2.start, block_size);
-										
+
 										// this is equivalent to rotating, but faster
 										// the area normally taken up by the A block is either the contents of buffer2, or data we don't need anymore since we memcopied it
 										// either way we don't need to retain the order of those items, so instead of rotating we can just block swap B to where it belongs
@@ -858,20 +865,20 @@ namespace Wiki {
 										// we are unable to use the 'buffer2' trick to speed up the rotation operation since buffer2 doesn't exist, so perform a normal rotation
 										Rotate(array, blockA.start - B_split, Range(B_split, blockA.start + block_size));
 									}
-									
+
 									// update the range for the remaining A blocks, and the range remaining from the B block after it was split
 									lastA = Range(blockA.start - B_remaining, blockA.start - B_remaining + block_size);
 									lastB = Range(lastA.end, lastA.end + B_remaining);
-									
+
 									// if there are no more A blocks remaining, this step is finished!
 									blockA.start += block_size;
 									if (blockA.length() == 0)
 										break;
-									
+
 								} else if (blockB.length() < block_size) {
 									// move the last B block, which is unevenly sized, to before the remaining A blocks, by using a rotation
 									Rotate(array, blockB.start - blockA.start, Range(blockA.start, blockB.end));
-									
+
 									lastB = Range(blockA.start, blockA.start + blockB.length());
 									blockA.start += blockB.length();
 									blockA.end += blockB.length();
@@ -880,17 +887,17 @@ namespace Wiki {
 									// roll the leftmost A block to the end by swapping it with the next B block
 									BlockSwap(array, blockA.start, blockB.start, block_size);
 									lastB = Range(blockA.start, blockA.start + block_size);
-									
+
 									blockA.start += block_size;
 									blockA.end += block_size;
 									blockB.start += block_size;
-									
+
 									if (blockB.end > B.end - block_size) blockB.end = B.end;
 									else blockB.end += block_size;
 								}
 							}
 						}
-						
+
 						// merge the last A block with the remaining B values
 						if (lastA.length() <= cache_size)
 							MergeExternal(array, lastA, Range(lastA.end, B.end), compare, cache);
@@ -900,14 +907,14 @@ namespace Wiki {
 							MergeInPlace(array, lastA, Range(lastA.end, B.end), compare);
 					}
 				}
-				
+
 				// when we're finished with this merge step we should have the one or two internal buffers left over, where the second buffer is all jumbled up
 				// insertion sort the second buffer, then redistribute the buffers back into the array using the opposite process used for creating the buffer
-				
+
 				// while an unstable sort like std::sort could be applied here, in benchmarks it was consistently slightly slower than a simple insertion sort,
 				// even for tens of millions of items. this may be because insertion sort is quite fast when the data is already somewhat sorted, like it is here
 				InsertionSort(array, buffer2, compare);
-				
+
 				for (pull_index = 0; pull_index < 2; pull_index++) {
 					size_t unique = pull[pull_index].count * 2;
 					if (pull[pull_index].from > pull[pull_index].to) {
@@ -935,7 +942,7 @@ namespace Wiki {
 					}
 				}
 			}
-			
+
 			// double the size of each A and B subarray that will be merged in the next level
 			if (!iterator.nextLevel()) break;
 		}
@@ -952,7 +959,7 @@ public:
 #if VERIFY
 	size_t index;
 #endif
-	
+
 #if PROFILE
 	Test& operator=(const Test & rhs) {
 		assignments++;
@@ -974,14 +981,14 @@ bool TestCompare(Test item1, Test item2) {
 	#if PROFILE
 		comparisons++;
 	#endif
-	
+
 	#if SLOW_COMPARISONS
 		// test slow comparisons by adding some fake overhead
 		// (in real-world use this might be string comparisons, etc.)
 		for (size_t index = 0; index < NOOP_SIZE; index++)
 			noop1[index] = noop2[index];
 	#endif
-	
+
 	return (item1.value < item2.value);
 }
 
@@ -999,10 +1006,10 @@ void Verify(const Test array[], const Range range, const Comparison compare, con
 		// if both values are equal, we need to make sure the index values are ascending
 		if (!(compare(array[index - 1], array[index]) ||
 			  (!compare(array[index], array[index - 1]) && array[index].index > array[index - 1].index))) {
-			
+
 			//for (size_t index2 = range.start; index2 < range.end; index2++)
 			//	cout << array[index2].value << " (" << array[index2].index << ") ";
-			
+
 			cout << endl << "failed with message: " << msg << endl;
 			assert(false);
 		}
@@ -1014,39 +1021,39 @@ namespace Testing {
 	size_t Random(size_t index, size_t total) {
 		return rand();
 	}
-	
+
 	size_t RandomFew(size_t index, size_t total) {
 		return rand() * (100.0/RAND_MAX);
 	}
-	
+
 	size_t MostlyDescending(size_t index, size_t total) {
 		return total - index + rand() * 1.0/RAND_MAX * 5 - 2.5;
 	}
-	
+
 	size_t MostlyAscending(size_t index, size_t total) {
 		return index + rand() * 1.0/RAND_MAX * 5 - 2.5;
 	}
-	
+
 	size_t Ascending(size_t index, size_t total) {
 		return index;
 	}
-	
+
 	size_t Descending(size_t index, size_t total) {
 		return total - index;
 	}
-	
+
 	size_t Equal(size_t index, size_t total) {
 		return 1000;
 	}
-	
+
 	size_t Jittered(size_t index, size_t total) {
 		return (rand() * 1.0/RAND_MAX <= 0.9) ? index : (index - 2);
 	}
-	
+
 	size_t MostlyEqual(size_t index, size_t total) {
 		return 1000 + rand() * 1.0/RAND_MAX * 4;
 	}
-	
+
 	// the last 1/5 of the data is random
 	size_t Append(size_t index, size_t total) {
 		if (index > total - total/5) return rand() * 1.0/RAND_MAX * total;
@@ -1058,18 +1065,18 @@ int main() {
 	const size_t max_size = 1500000;
 	__typeof__(&TestCompare) compare = &TestCompare;
 	vector<Test> array1, array2;
-	
+
 	#if PROFILE
 		size_t compares1, compares2, total_compares1 = 0, total_compares2 = 0;
 		size_t assigns1, assigns2, total_assigns1 = 0, total_assigns2 = 0;
 	#endif
-	
+
 	// initialize the random-number generator
 	//srand(time(NULL));
 	srand(10141985); // in case you want the same random numbers
-	
+
 	size_t total = max_size;
-	
+
 #if !SLOW_COMPARISONS && VERIFY
 	__typeof__(&Testing::Random) test_cases[] = {
 		Testing::Random,
@@ -1083,7 +1090,7 @@ int main() {
 		Testing::MostlyEqual,
 		Testing::Append
 	};
-	
+
 	cout << "running test cases... " << flush;
 	array1.resize(total);
 	array2.resize(total);
@@ -1092,39 +1099,39 @@ int main() {
 			Test item = Test();
 			item.value = test_cases[test_case](index, total);
 			item.index = index;
-			
+
 			array1[index] = array2[index] = item;
 		}
 		Wiki::Sort(array1.begin(), array1.end(), compare);
 		stable_sort(array2.begin(), array2.end(), compare);
-		
+
 		Verify(&array1[0], Range(0, total), compare, "test case failed");
 		for (size_t index = 0; index < total; index++)
 			assert(!compare(array1[index], array2[index]) && !compare(array2[index], array1[index]));
 	}
 	cout << "passed!" << endl;
 #endif
-	
+
 	double total_time = Seconds();
 	double total_time1 = 0, total_time2 = 0;
-	
+
 	for (total = 0; total <= max_size; total += 2048 * 16) {
 		array1.resize(total);
 		array2.resize(total);
-		
+
 		for (size_t index = 0; index < total; index++) {
 			Test item = Test();
-			
+
 			// Random, RandomFew, MostlyDescending, MostlyAscending,
 			// Ascending, Descending, Equal, Jittered, MostlyEqual, Append
 			item.value = Testing::Random(index, total);
 			#if VERIFY
 				item.index = index;
 			#endif
-			
+
 			array1[index] = array2[index] = item;
 		}
-		
+
 		double time1 = Seconds();
 		#if PROFILE
 			comparisons = assignments = 0;
@@ -1132,19 +1139,19 @@ int main() {
 		Wiki::Sort(array1.begin(), array1.end(), compare);
 		time1 = Seconds() - time1;
 		total_time1 += time1;
-		
+
 		#if PROFILE
 			compares1 = comparisons;
 			total_compares1 += compares1;
 			assigns1 = assignments;
 			total_assigns1 += assigns1;
 		#endif
-		
+
 		double time2 = Seconds();
 		#if PROFILE
 			comparisons = assignments = 0;
 		#endif
-		
+
 		#if TEST_INPLACE
 			__inplace_stable_sort(array2.begin(), array2.end(), compare);
 		#else
@@ -1152,51 +1159,51 @@ int main() {
 		#endif
 		time2 = Seconds() - time2;
 		total_time2 += time2;
-		
+
 		#if PROFILE
 			compares2 = comparisons;
 			total_compares2 += compares2;
 			assigns2 = assignments;
 			total_assigns2 += assigns2;
 		#endif
-		
+
 		cout << "[" << total << "]" << endl;
-		
+
 		if (time1 >= time2) cout << "WikiSort: " << time1 << " seconds, stable_sort: " << time2 << " seconds (" << time2/time1 * 100.0 << "% as fast)" << endl;
 		else cout << "WikiSort: " << time1 << " seconds, stable_sort: " << time2 << " seconds (" << time2/time1 * 100.0 - 100.0 << "% faster)" << endl;
-		
+
 		#if PROFILE
 			if (compares1 <= compares2) cout << "WikiSort: " << compares1 << " compares, stable_sort: " << compares2 << " compares (" << compares1 * 100.0/compares2 << "% as many)" << endl;
 			else cout << "WikiSort: " << compares1 << " compares, stable_sort: " << compares2 << " compares (" << compares1 * 100.0/compares2 - 100.0 << "% more)" << endl;
-			
+
 			if (assigns1 <= assigns2) cout << "WikiSort: " << assigns1 << " assigns, stable_sort: " << assigns2 << " assigns (" << assigns1 * 100.0/assigns2 << "% as many)" << endl;
 			else cout << "WikiSort: " << assigns1 << " assigns, stable_sort: " << assigns2 << " assigns (" << assigns1 * 100.0/assigns2 - 100.0 << "% more)" << endl;
 		#endif
-		
+
 		#if VERIFY
 			// make sure the arrays are sorted correctly, and that the results were stable
 			cout << "verifying... " << flush;
-			
+
 			Verify(&array1[0], Range(0, total), compare, "testing the final array");
 			for (size_t index = 0; index < total; index++)
 				assert(!compare(array1[index], array2[index]) && !compare(array2[index], array1[index]));
-			
+
 			cout << "correct!" << endl;
 		#endif
 	}
-	
+
 	total_time = Seconds() - total_time;
 	cout << "Tests completed in " << total_time << " seconds" << endl;
 	if (total_time1 >= total_time2) cout << "WikiSort: " << total_time1 << " seconds, stable_sort: " << total_time2 << " seconds (" << total_time2/total_time1 * 100.0 << "% as fast)" << endl;
 	else cout << "WikiSort: " << total_time1 << " seconds, stable_sort: " << total_time2 << " seconds (" << total_time2/total_time1 * 100.0 - 100.0 << "% faster)" << endl;
-	
+
 	#if PROFILE
 		if (total_compares1 <= total_compares2) cout << "WikiSort: " << total_compares1 << " compares, stable_sort: " << total_compares2 << " compares (" << total_compares1 * 100.0/total_compares2 << "% as many)" << endl;
 		else cout << "WikiSort: " << total_compares1 << " compares, stable_sort: " << total_compares2 << " compares (" << total_compares1 * 100.0/total_compares2 - 100.0 << "% more)" << endl;
-		
+
 		if (total_assigns1 <= total_assigns2) cout << "WikiSort: " << total_assigns1 << " assigns, stable_sort: " << total_assigns2 << " assigns (" << total_assigns1 * 100.0/total_assigns2 << "% as many)" << endl;
 		else cout << "WikiSort: " << total_assigns1 << " assigns, stable_sort: " << total_assigns2 << " assigns (" << total_assigns1 * 100.0/total_assigns2 - 100.0 << "% more)" << endl;
 	#endif
-	
+
 	return 0;
 }


### PR DESCRIPTION
I wanted to add a block sort to my sorting library and WikiSort seemed like the perfect implementation, so I took it and improved some things on-the-fly. While some things are not really compatible with C++03, this pull request is fully compatible with C++03.

Basically, I simply replaced every call to `std::swap` by a call to [`std::iter_swap`](http://en.cppreference.com/w/cpp/algorithm/iter_swap). The latter uses ADL to check whether the type to be swapped has a `swap` function in its namespace. If such a function exists, it uses it, otherwise it falls back to `std::swap`. While it doesn't change the correctness of the program, ADL-found swaps are generally optimized swaps for some classes, which means that WikiSort could end up being faster for free for some types while still being as fast as before for the other ones.

*As a side note, my IDE strips all the useless spaces before a newline when I save, but removing useless spaces can't be a bad thing, right?*